### PR TITLE
fix(workflow_from_template): allow explicit-empty iac_input_data to clear template default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/StackGuardian/terraform-provider-stackguardian
 go 1.21.4
 
 require (
-	github.com/StackGuardian/sg-sdk-go v1.5.4
+	github.com/StackGuardian/sg-sdk-go v1.5.5
 	github.com/hashicorp/terraform-plugin-framework v1.11.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/StackGuardian/sg-sdk-go v1.5.4 h1:MGRN+62Ru+llBVi10zsaZ+08Y1qqYGmsORGum77YJ44=
-github.com/StackGuardian/sg-sdk-go v1.5.4/go.mod h1:iCrgHE0WbxEaaLx6ATsRe81Qjp82kahCwLGJ2t66mZ0=
+github.com/StackGuardian/sg-sdk-go v1.5.5 h1:r/4g1qeBXsUCTI66FczugYtSCGm+G8vsDii6DjcZcIk=
+github.com/StackGuardian/sg-sdk-go v1.5.5/go.mod h1:iCrgHE0WbxEaaLx6ATsRe81Qjp82kahCwLGJ2t66mZ0=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/internal/resource/stack_template_revision/model.go
+++ b/internal/resource/stack_template_revision/model.go
@@ -956,7 +956,11 @@ func convertVcsConfigToAPI(ctx context.Context, obj types.Object, orgName string
 		vcsConfig.IacInputData = &sgsdkgo.IacInputData{
 			SchemaId:   idModel.SchemaId.ValueStringPointer(),
 			SchemaType: &schemaType,
-			Data:       parseJSONToMap(idModel.Data.ValueString()),
+		}
+		// Data is *map: nil map (empty/invalid string) leaves the pointer nil -> key
+		// omitted, matching prior omitempty behavior; a non-nil map (incl. {}) is sent.
+		if dataMap := parseJSONToMap(idModel.Data.ValueString()); dataMap != nil {
+			vcsConfig.IacInputData.Data = &dataMap
 		}
 	}
 
@@ -1862,10 +1866,16 @@ func vcsConfigFromAPI(vc *sgsdkgo.VcsConfig) (types.Object, diag.Diagnostics) {
 
 	iacInputNull := types.ObjectNull(IacInputDataModel{}.AttributeTypes())
 	if vc.IacInputData != nil {
+		// Data is *map: guard the nil pointer — a typed nil inside interface{} would slip
+		// past marshalToJSONString's nil check and marshal to the string "null".
+		dataStr := types.StringNull()
+		if vc.IacInputData.Data != nil {
+			dataStr = marshalToJSONString(*vc.IacInputData.Data)
+		}
 		idM := IacInputDataModel{
 			SchemaId:   flatteners.StringPtr(vc.IacInputData.SchemaId),
 			SchemaType: flatteners.String(string(*vc.IacInputData.SchemaType)),
-			Data:       marshalToJSONString(vc.IacInputData.Data),
+			Data:       dataStr,
 		}
 		var diags diag.Diagnostics
 		iacInputNull, diags = types.ObjectValueFrom(context.Background(), IacInputDataModel{}.AttributeTypes(), idM)
@@ -1917,6 +1927,8 @@ func workflowsConfigFromAPI(wc *stacktemplaterevisions.StackTemplateRevisionWork
 		// IacInputData (TemplatesIacInputData)
 		iacInputDataObj := types.ObjectNull(WfStepInputDataModel{}.AttributeTypes())
 		if wf.IacInputData != nil {
+			// wf.IacInputData is TemplatesIacInputData (Data is a plain map, not the
+			// pointer-typed sgsdkgo.IacInputData) — no deref needed.
 			idm := WfStepInputDataModel{
 				SchemaType: flatteners.String(string(*wf.IacInputData.SchemaType)),
 				Data:       marshalToJSONString(wf.IacInputData.Data),

--- a/internal/resource/workflow_from_template/model.go
+++ b/internal/resource/workflow_from_template/model.go
@@ -511,7 +511,12 @@ func (m IacInputDataModel) ToAPIModel() *sgsdkgo.IacInputData {
 		out.SchemaType = sgsdkgo.IacInputDataSchemaTypeEnum(m.SchemaType.ValueString()).Ptr()
 	}
 	if isNonEmpty(m.Data) {
-		out.Data = expanders.JSONStringToMap(m.Data.ValueString())
+		// Data is a pointer so an EXPLICIT empty object reaches the wire: data = "{}"
+		// parses to an empty (non-nil) map and serializes as "data": {}, which the API
+		// accepts and which suppresses template inheritance (see fillTemplateIacInputData).
+		// A null/"" data leaves the pointer nil -> key omitted -> inherit.
+		dataMap := expanders.JSONStringToMap(m.Data.ValueString())
+		out.Data = &dataMap
 	}
 	return out
 }
@@ -2147,10 +2152,16 @@ func convertVcsConfigFromAPI(ctx context.Context, vcsConfig *sgsdkgo.VcsConfig) 
 		} else {
 			schemaType = types.StringValue("")
 		}
+		// Data is *map: guard the nil pointer explicitly — a typed nil inside interface{}
+		// would slip past JSONInterfaceToString's nil check and marshal to the string "null".
+		dataStr := types.StringNull()
+		if vcsConfig.IacInputData.Data != nil {
+			dataStr = flatteners.JSONInterfaceToString(*vcsConfig.IacInputData.Data)
+		}
 		iacInputDataModel := IacInputDataModel{
 			SchemaId:   knownEmptyStringIfNull(flatteners.StringPtr(vcsConfig.IacInputData.SchemaId)),
 			SchemaType: schemaType,
-			Data:       knownEmptyStringIfNull(flatteners.JSONInterfaceToString(vcsConfig.IacInputData.Data)),
+			Data:       knownEmptyStringIfNull(dataStr),
 		}
 		var diags diag.Diagnostics
 		iacInputDataObj, diags = types.ObjectValueFrom(ctx, IacInputDataModel{}.AttributeTypes(), iacInputDataModel)
@@ -2472,8 +2483,10 @@ func extractFormJSONSchemaDefaults(schema map[string]interface{}) interface{} {
 // the data is one opaque JSON string so it cannot be merged key-by-key. This matches the
 // replace semantics used for environment_variables and other lists.
 func fillTemplateIacInputData(wf *sgworkflows.Workflow, tpl *workflowtemplaterevisions.ReadWorkflowTemplateRevisionModel) {
-	// User already supplied input data → leave it untouched.
-	if wf.VcsConfig != nil && wf.VcsConfig.IacInputData != nil && len(wf.VcsConfig.IacInputData.Data) > 0 {
+	// User already supplied input data → leave it untouched. Data is a pointer: a non-nil
+	// pointer means the user DECLARED data — including an EXPLICIT empty {} (data = "{}"),
+	// which must suppress template inheritance, not fall through to it.
+	if wf.VcsConfig != nil && wf.VcsConfig.IacInputData != nil && wf.VcsConfig.IacInputData.Data != nil {
 		return
 	}
 	tplData := templateDefaultInputData(tpl)
@@ -2486,7 +2499,7 @@ func fillTemplateIacInputData(wf *sgworkflows.Workflow, tpl *workflowtemplaterev
 	schemaType := sgsdkgo.IacInputDataSchemaTypeEnumFormJsonschema
 	wf.VcsConfig.IacInputData = &sgsdkgo.IacInputData{
 		SchemaType: &schemaType,
-		Data:       tplData,
+		Data:       &tplData,
 	}
 }
 

--- a/internal/resource/workflow_from_template/resource_iac_input_clear_test.go
+++ b/internal/resource/workflow_from_template/resource_iac_input_clear_test.go
@@ -1,0 +1,163 @@
+package workflowfromtemplate_test
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	sgsdkgo "github.com/StackGuardian/sg-sdk-go"
+	"github.com/StackGuardian/sg-sdk-go/core"
+	"github.com/StackGuardian/sg-sdk-go/workflowtemplaterevisions"
+	"github.com/StackGuardian/sg-sdk-go/workflowtemplates"
+	"github.com/StackGuardian/terraform-provider-stackguardian/internal/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+)
+
+// setupTemplateWithInputDefaults creates and publishes a TERRAFORM template revision whose
+// FORM_JSONSCHEMA carries property defaults (env=staging, region=eu) — so the provider's
+// templateDefaultInputData resolves a non-empty default iac_input_data for workflows that
+// omit it. Backs the explicit-empty (WFT-CLEAR-002) test. Registers cleanup.
+func setupTemplateWithInputDefaults(t *testing.T, name string) string {
+	t.Helper()
+	client := getClient()
+	sck := workflowtemplates.WorkflowTemplateSourceConfigKindTerraform
+	is409 := func(err error) bool {
+		var apiErr *core.APIError
+		return errors.As(err, &apiErr) && apiErr.StatusCode == 409
+	}
+
+	_, err := client.WorkflowTemplates.CreateWorkflowTemplate(context.TODO(), org, false,
+		&workflowtemplates.CreateWorkflowTemplateRequest{
+			Id: &name, TemplateName: name, SourceConfigKind: &sck,
+			TemplateType: sgsdkgo.TemplateTypeEnum("IAC"), IsPublic: sgsdkgo.IsPublicEnumZero.Ptr(),
+			OwnerOrg: fmt.Sprintf("/orgs/%s", org),
+		})
+	if err != nil && !is409(err) {
+		t.Fatalf("create tpl: %s", err)
+	}
+
+	formSchema := base64.StdEncoding.EncodeToString([]byte(`{
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"type": "object",
+		"properties": {
+			"env":    {"type": "string", "default": "staging"},
+			"region": {"type": "string", "default": "eu"}
+		}
+	}`))
+	isCommitted := true
+	_, err = client.WorkflowTemplatesRevisions.CreateWorkflowTemplateRevision(context.TODO(), org, name,
+		&workflowtemplaterevisions.CreateWorkflowTemplateRevisionsRequest{
+			Alias: "v1", SourceConfigKind: &sck, IsPublic: sgsdkgo.IsPublicEnumZero.Ptr(),
+			OwnerOrg: fmt.Sprintf("/orgs/%s", org),
+			InputSchemas: []sgsdkgo.InputSchemas{
+				{
+					Type:        sgsdkgo.InputSchemasTypeEnumFormJsonschema,
+					EncodedData: &formSchema,
+					IsCommitted: &isCommitted,
+				},
+			},
+		})
+	if err != nil && !is409(err) {
+		t.Fatalf("create rev: %s", err)
+	}
+
+	revisionID := name + ":1"
+	if _, err := client.WorkflowTemplatesRevisions.UpdateWorkflowTemplateRevision(context.TODO(), org, revisionID,
+		&workflowtemplaterevisions.UpdateWorkflowTemplateRevisionRequest{IsPublic: sgsdkgo.Optional(sgsdkgo.IsPublicEnumOne)}); err != nil {
+		t.Fatalf("publish rev: %s", err)
+	}
+	if _, err := client.WorkflowTemplates.UpdateWorkflowTemplate(context.TODO(), org, name,
+		&workflowtemplates.UpdateWorkflowTemplateRequest{IsPublic: sgsdkgo.Optional(sgsdkgo.IsPublicEnumOne)}); err != nil {
+		t.Fatalf("publish tpl: %s", err)
+	}
+	t.Cleanup(func() {
+		eff := fmt.Sprintf("%d", time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC).Unix())
+		msg := "cleanup"
+		client.WorkflowTemplatesRevisions.UpdateWorkflowTemplateRevision(context.TODO(), org, revisionID,
+			&workflowtemplaterevisions.UpdateWorkflowTemplateRevisionRequest{
+				Deprecation: sgsdkgo.Optional(workflowtemplaterevisions.Deprecation{EffectiveDate: &eff, Message: &msg})})
+		client.WorkflowTemplatesRevisions.DeleteWorkflowTemplateRevision(context.TODO(), org, revisionID, true)
+		client.WorkflowTemplates.DeleteWorkflowTemplate(context.TODO(), org, name)
+	})
+	return fmt.Sprintf("/%s/%s:1", org, name)
+}
+
+// TestAccWorkflowUsingTemplate_ExplicitEmptyIacInputData verifies WFT-CLEAR-002: a template
+// carries default input data (FORM_JSONSCHEMA defaults), and the user declares an EXPLICIT
+// empty data ("{}") to CLEAR it instead of inheriting. Previously this failed with
+// 'VCSConfig.iacInputData.data: This field is required' — the SDK's json omitempty on the
+// plain-map Data field silently dropped the empty map from the payload. With Data as a
+// pointer, "data": {} reaches the wire, the API accepts it, and inheritance is suppressed.
+// Also asserts the omit case still inherits (control), and the clear round-trips (clean plan).
+func TestAccWorkflowUsingTemplate_ExplicitEmptyIacInputData(t *testing.T) {
+	templateID := setupTemplateWithInputDefaults(t, "tf-iacclear-tpl")
+	wfGrp := "tf-iacclear-wfgrp"
+	if err := createWorkflowGroupFixture(wfGrp); err != nil {
+		t.Fatalf("wfgrp fixture: %s", err)
+	}
+	defer deleteWorkflowGroupFixture(wfGrp)
+	defer deleteWorkflowUsingTemplateFixture(wfGrp, "tf-iacclear-inherit")
+	defer deleteWorkflowUsingTemplateFixture(wfGrp, "tf-iacclear-empty")
+
+	// Control: omits iac_input_data -> inherits the template defaults.
+	// Subject: declares data = "{}" -> clears (suppresses inheritance).
+	cfg := fmt.Sprintf(`
+resource "stackguardian_workflow_from_template" "inherit" {
+  workflow_group_id = %q
+  id                = "tf-iacclear-inherit"
+  wf_type           = "TERRAFORM"
+  vcs_config = {
+    iac_vcs_config = {
+      iac_template_id = %q
+    }
+  }
+  terraform_config = {
+    terraform_version = "1.5.0"
+  }
+}
+
+resource "stackguardian_workflow_from_template" "empty" {
+  workflow_group_id = %q
+  id                = "tf-iacclear-empty"
+  wf_type           = "TERRAFORM"
+  vcs_config = {
+    iac_vcs_config = {
+      iac_template_id = %q
+    }
+    iac_input_data = {
+      schema_type = "RAW_JSON"
+      data        = "{}"
+    }
+  }
+  terraform_config = {
+    terraform_version = "1.5.0"
+  }
+}
+`, wfGrp, templateID, wfGrp, templateID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		TerraformVersionChecks:   []tfversion.TerraformVersionCheck{tfversion.SkipBelow(tfversion.Version1_1_0)},
+		ProtoV6ProviderFactories: acctest.ProviderFactories(customHeader()),
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Control inherits the FORM_JSONSCHEMA defaults.
+					resource.TestCheckResourceAttr("stackguardian_workflow_from_template.inherit", "vcs_config.iac_input_data.data", `{"env":"staging","region":"eu"}`),
+					// Subject's explicit empty is honored — template defaults NOT inherited.
+					resource.TestCheckResourceAttr("stackguardian_workflow_from_template.empty", "vcs_config.iac_input_data.data", "{}"),
+				),
+			},
+			{
+				// Round-trip stability: no perpetual diff on the cleared value.
+				Config:   cfg,
+				PlanOnly: true,
+			},
+		},
+	})
+}

--- a/internal/resource/workflow_git/model.go
+++ b/internal/resource/workflow_git/model.go
@@ -659,11 +659,17 @@ func (IacInputDataModel) AttributeTypes() map[string]attr.Type {
 }
 
 func (m IacInputDataModel) ToAPIModel() *sgsdkgo.IacInputData {
-	return &sgsdkgo.IacInputData{
+	out := &sgsdkgo.IacInputData{
 		SchemaId:   m.SchemaId.ValueStringPointer(),
 		SchemaType: sgsdkgo.IacInputDataSchemaTypeEnum(m.SchemaType.ValueString()).Ptr(),
-		Data:       expanders.JSONStringToMap(m.Data.ValueString()),
 	}
+	// Data is *map: JSONStringToMap returns a nil map for "" (leave pointer nil -> key
+	// omitted, matching prior omitempty behavior) and a non-nil map otherwise (incl. the
+	// empty {} for "{}", which now reaches the wire as an explicit empty).
+	if dataMap := expanders.JSONStringToMap(m.Data.ValueString()); dataMap != nil {
+		out.Data = &dataMap
+	}
+	return out
 }
 
 type CustomSourceConfigModel struct {
@@ -2234,10 +2240,16 @@ func convertVcsConfigFromAPI(ctx context.Context, vcsConfig *sgsdkgo.VcsConfig) 
 
 	var iacInputDataObj types.Object
 	if vcsConfig.IacInputData != nil {
+		// Data is *map: guard the nil pointer — a typed nil inside interface{} would slip
+		// past JSONInterfaceToString's nil check and marshal to the string "null".
+		dataStr := types.StringNull()
+		if vcsConfig.IacInputData.Data != nil {
+			dataStr = flatteners.JSONInterfaceToString(*vcsConfig.IacInputData.Data)
+		}
 		iacInputDataModel := IacInputDataModel{
 			SchemaId:   flatteners.StringPtr(vcsConfig.IacInputData.SchemaId),
 			SchemaType: types.StringValue(string(*vcsConfig.IacInputData.SchemaType)),
-			Data:       flatteners.JSONInterfaceToString(vcsConfig.IacInputData.Data),
+			Data:       dataStr,
 		}
 		var diags diag.Diagnostics
 		iacInputDataObj, diags = types.ObjectValueFrom(ctx, IacInputDataModel{}.AttributeTypes(), iacInputDataModel)


### PR DESCRIPTION
## Problem

Setting `vcs_config.iac_input_data.data = "{}"` to **clear** a template's default input data (instead of inheriting it) failed with:

```
VCSConfig.iacInputData.data: This field is required
```

(Found via terraform-provider test **WFT-CLEAR-002**.)

## Root cause — sg-sdk-go

`IacInputData.Data` was a plain `map[string]interface{}` with `json:"data,omitempty"`. Go's JSON marshaling **silently drops an empty map**, so `data: {}` never reached the wire. The API's VCSConfig serializer requires the `data` key whenever `iacInputData` is present (`DictField(required=True, allow_null=False)`) and **accepts** `{}` — so the dropped key surfaced as the required-field error even though the provider had correctly built an empty map.

Fixed in **sg-sdk-go v1.5.5** (PR StackGuardian/sg-sdk-go#33): `Data` is now `*map[string]interface{}` — nil omits the key, a pointer to an empty map sends `"data": {}`.

## This PR

Bumps the provider to **v1.5.5** and adapts every `.Data` touchpoint across `workflow_from_template`, `workflow_git`, and `stack_template_revision`:

- **ToAPIModel / expanders** — set the pointer only when the parsed map is non-nil, so an explicit `{}` reaches the wire while a null/`""` stays omitted (inherit).
- **`fillTemplateIacInputData`** — inherit only when `Data == nil`, so an explicit `{}` now **suppresses** template inheritance instead of falling through to the default.
- **fromAPI flatteners** — nil-guard the pointer (a typed nil inside `interface{}` would otherwise marshal to the string `"null"`).

## Test

`TestAccWorkflowUsingTemplate_ExplicitEmptyIacInputData` (WFT-CLEAR-002): a template with FORM_JSONSCHEMA defaults — the control workflow inherits `{"env":"staging","region":"eu"}`, the subject declares `data = "{}"` and clears them, and the re-plan is clean.

## Verification

Full acceptance suite green live on QA against **published v1.5.5** — including the new test, the existing `WithIacInputData` / `TemplateDefaultsResolved`, and `workflow_git`'s `WithIacInputData` (proving the pointer adaptation didn't break the other resources).